### PR TITLE
Site 3297 request scope spring update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-framework-bom</artifactId>
-                <version>4.2.4.RELEASE</version>
+                <version>4.3.30.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.sitenv</groupId>
     <artifactId>referenceccdavalidator</artifactId>
-    <version>1.0.58</version>
+    <version>1.0.59-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Reference CCDA Validator</name>
 

--- a/src/main/java/org/sitenv/referenceccda/validators/content/ReferenceContentValidator.java
+++ b/src/main/java/org/sitenv/referenceccda/validators/content/ReferenceContentValidator.java
@@ -12,12 +12,14 @@ import org.sitenv.referenceccda.validators.enums.ValidationResultType;
 import org.sitenv.vocabularies.constants.VocabularyConstants.SeverityLevel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
 import org.xml.sax.SAXException;
 
 
 /**
  * Created by Brian on 8/15/2016.
  */
+@RequestScope
 @Component
 public class ReferenceContentValidator extends BaseCCDAValidator implements CCDAValidator {
     private ContentValidatorService contentValidatorService;

--- a/src/main/java/org/sitenv/referenceccda/validators/schema/ReferenceCCDAValidator.java
+++ b/src/main/java/org/sitenv/referenceccda/validators/schema/ReferenceCCDAValidator.java
@@ -55,8 +55,10 @@ import org.sitenv.referenceccda.validators.enums.ValidationResultType;
 import org.sitenv.vocabularies.constants.VocabularyConstants;
 import org.sitenv.vocabularies.constants.VocabularyConstants.SeverityLevel;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
 import org.xml.sax.SAXException;
 
+@RequestScope
 @Component
 public class ReferenceCCDAValidator extends BaseCCDAValidator implements CCDAValidator {
 	private static Logger logger = Logger.getLogger(ReferenceCCDAValidator.class);

--- a/src/main/java/org/sitenv/referenceccda/validators/vocabulary/VocabularyCCDAValidator.java
+++ b/src/main/java/org/sitenv/referenceccda/validators/vocabulary/VocabularyCCDAValidator.java
@@ -19,8 +19,10 @@ import org.sitenv.vocabularies.validation.services.VocabularyValidationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
 import org.xml.sax.SAXException;
 
+@RequestScope
 @Component
 public class VocabularyCCDAValidator extends BaseCCDAValidator implements CCDAValidator {
     @Value("${referenceccda.configFile}")


### PR DESCRIPTION
This bumps the version of the Spring Framework so we can leverage @RequestScope annotation. This annotation's intent is explicit. The annotation was added to the validator @Component beans so each request is presented with its own instance rather than being singleton scoped in the Spring Container.