### PR TITLE
3.1.62 Release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.sitenv</groupId>
     <artifactId>referenceccdavalidator</artifactId>
-    <version>1.0.66</version>
+    <version>1.0.67</version>
     <packaging>war</packaging>
     <name>Reference CCDA Validator</name>
 
@@ -16,11 +16,11 @@
         <content.validator.version>latestVersion</content.validator.version>
         <!-- MDHT SITE properties -->
         <mdht.models.groupid>mdht.openhealthtools.mdht.cda</mdht.models.groupid>
-        <mdht.models.version>3.0.0.20220825</mdht.models.version>
+        <mdht.models.version>3.0.0.20220923</mdht.models.version>
         <ds4pcontent.groupId>mdht.hl7.ds4p</ds4pcontent.groupId>
 		<ds4pcontent.version>${mdht.models.version}</ds4pcontent.version>		
 		<mdht.plugins.groupId>mdht.eclipse.mdht</mdht.plugins.groupId>
-		<mdht.plugins.version>3.0.0.202208250500</mdht.plugins.version>
+		<mdht.plugins.version>3.0.0.202209230500</mdht.plugins.version>
 		<logback.version>1.2.11</logback.version>
  		<!-- MDHT SNAPSHOT properties: Uncomment for local test -->
  		<!--
@@ -84,7 +84,7 @@
 		    <version>${mdht.plugins.version}</version>
 		</dependency>
 		<dependency>
-            <groupId>mdht.eclipse.mdht</groupId>
+            <groupId>${mdht.plugins.groupId}</groupId>
             <artifactId>org.eclipse.mdht.uml.hl7.vocab</artifactId>
 		    <version>${mdht.plugins.version}</version>
 		</dependency>	


### PR DESCRIPTION
* Update to 1.0.67-SNAPSHOT for next release

* updates for sept release

updated to latest mdht models

* Update MDHT plugins to 3.0.0.202209230500 to sync with models

* Update from 1.0.67-SNAPSHOT to 1.0.67 for 3.1.62 SITE Release

Co-authored-by: Dan Brown <dbrown.se@gmail.com>
Co-authored-by: sean.muir@bookzurman.com <sean.muir@bookzurman.com>